### PR TITLE
Modernize TypeScript configuration and strengthen typing

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -9,7 +9,7 @@ module.exports = {
   entry: [
     'webpack-dev-server/client?http://localhost:8080',
     'webpack/hot/only-dev-server',
-    './index.js',
+    './index.tsx',
   ],
   output: {
     filename: 'bundle.js',

--- a/config/webpack.config.docs.js
+++ b/config/webpack.config.docs.js
@@ -4,7 +4,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 module.exports = {
   mode: 'production',
   devtool: 'source-map',
-  entry: './index.js',
+  entry: './index.tsx',
   output: {
     filename: 'bundle.js',
     path: resolve(__dirname, '../docs'),

--- a/index.tsx
+++ b/index.tsx
@@ -5,5 +5,10 @@ import { createRoot } from 'react-dom/client'
 import TestApp from './src/TestApp'
 
 const container = document.getElementById('app')
+
+if (!container) {
+  throw new Error('Unable to find root element with id "app"')
+}
+
 const root = createRoot(container)
 root.render(<TestApp />)

--- a/lib/scss.d.ts
+++ b/lib/scss.d.ts
@@ -1,0 +1,4 @@
+declare module '*.scss' {
+  const content: { readonly [className: string]: string }
+  export default content
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "start": "node_modules/.bin/webpack-dev-server --config config/webpack.config.dev.js",
     "build": "webpack --config config/webpack.config.prod.js",
+    "typecheck": "tsc --noEmit -p tsconfig.app.json",
     "test": "echo \"No test specified\" && exit 0",
     "prepare": "npm run build",
     "docs": "webpack --config config/webpack.config.docs.js"

--- a/src/TestApp.tsx
+++ b/src/TestApp.tsx
@@ -4,7 +4,7 @@ import ReactDice, { ReactDiceRef } from '../lib/ReactDice'
 
 const TestApp = () => {
   const [defaultRoll, setDefaultRoll] = useState(1)
-  const [diceTotal, setDiceTotal] = useState()
+  const [diceTotal, setDiceTotal] = useState<number>()
   const [dieCornerRadius, setDieCornerRadius] = useState(5)
   const [dieSize, setDieSize] = useState(60)
   const [disableIndividual, setDisableIndividual] = useState(false)
@@ -21,7 +21,7 @@ const TestApp = () => {
 
   const reactDice = useRef<ReactDiceRef>(null)
 
-  const rollDone = (value, values) => {
+  const rollDone = (value: number, values: number[]) => {
     setRolling(false)
     setDiceTotal(value)
   }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["lib", "src", "index.tsx"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,20 @@
 {
   "compilerOptions": {
-    "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "declaration": true,
     "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
     "jsx": "react",
-    "module": "es6",
-    "moduleResolution": "nodenext",
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "outDir": "./dist/",
+    "rootDir": "./lib",
+    "skipLibCheck": true,
     "sourceMap": true,
-    "strictNullChecks": true,
-    "target": "es5"
+    "strict": true,
+    "target": "ES2020"
   },
-  "include": ["./lib/"]
+  "include": ["lib"]
 }


### PR DESCRIPTION
## Summary

Modernizes the TypeScript setup so the codebase is fully and strictly typed, without changing any runtime behavior.

The library source was already `.tsx`, but the compiler config was loose (only `strictNullChecks`), one entry file was still plain JS, and the SCSS import had no type declaration. This tightens all of that.

## Changes

- **`tsconfig.json`**: enable full `strict` (was `strictNullChecks` only); bump `target` from `es5` to `ES2020`; switch to `module: ESNext` + `moduleResolution: bundler` (also fixes the previously invalid `nodenext`/`es6` pairing); add `isolatedModules`, `forceConsistentCasingInFileNames`, `skipLibCheck`, explicit `lib`. Scope the build config to `lib` with an explicit `rootDir` so emitted typings stay at `dist/ReactDice.d.ts`.
- **`lib/scss.d.ts`** (new): module declaration for the `import './styles.scss'` side-effect import.
- **`index.js` → `index.tsx`**: convert the last JS source file; update the dev and docs webpack entries.
- **`tsconfig.app.json`** (new) + **`typecheck`** npm script: type-checks the full project (lib + src demo + entry) under strict, separate from the lib-only build config.
- **`src/TestApp.tsx`**: type `rollDone(value, values)` params and `diceTotal` state (were implicit `any` / untyped).

## Verification

- `npm run typecheck` — passes under strict
- `npm run build` — full webpack build succeeds; compiles SCSS and emits `react-dice-complete.js` plus `ReactDice.d.ts` / `Die.d.ts` / `DiceContainer.d.ts`

No runtime behavior changes — purely typing and tooling.

https://claude.ai/code/session_01WZxB2pKeMMacz4juCo19DK

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZxB2pKeMMacz4juCo19DK)_