### PR TITLE
Fix dice faces becoming invisible on iOS/Safari (#83)

### DIFF
--- a/lib/styles.scss
+++ b/lib/styles.scss
@@ -4,6 +4,11 @@
   height: 60px;
   position: relative;
   transform-style: preserve-3d;
+  // iOS/Safari can flatten the 3D context and drop rotated-away faces
+  // (issue #83). Keep the preserve-3d context explicit and promote the
+  // die to its own compositing layer.
+  -webkit-transform-style: preserve-3d;
+  will-change: transform;
 
   &.init-roll1 {
     transform: rotateY(180deg);
@@ -78,6 +83,9 @@
     width: 60px;
     position: absolute;
     background: #3e6fa0;
+    // Cull back-facing sides so Safari renders the result face reliably (#83)
+    backface-visibility: hidden;
+    -webkit-backface-visibility: hidden;
   }
 
   .dot {


### PR DESCRIPTION
## Summary

Addresses **#83** — dice faces becoming invisible while rolling on iPhone/iPad. A commenter narrowed it to results **2–4** (the faces rotated furthest from the camera) in iOS/WebKit.

The root cause is Safari's well-known fragility with `transform-style: preserve-3d`: it can collapse the 3D context and cull faces incorrectly. The current `styles.scss` has no Safari-specific mitigations.

## Changes (`lib/styles.scss`)

- `-webkit-transform-style: preserve-3d` on `.die` — keep the 3D context explicit for WebKit
- `will-change: transform` on `.die` — promote the die to its own compositing layer
- `backface-visibility: hidden` (+ `-webkit-`) on `.face` — cull back-facing sides so the result face renders reliably (the canonical fix for this symptom; should also help the related flashing in #28)

No JS/behavior changes; SCSS-only.

## Verification

- ✅ `npm run build` — SCSS compiles cleanly
- ⚠️ **Not yet verified on a physical iOS device.** This is a device-specific WebKit rendering bug, so it needs testing on a real iPhone/iPad before merge. Kept as a **draft** for that reason.

Closes #83 (pending iOS verification).

https://claude.ai/code/session_01WZxB2pKeMMacz4juCo19DK

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZxB2pKeMMacz4juCo19DK)_