### PR TITLE
Fix dice intermittently not animating on rollAll

### DIFF
--- a/lib/Die.tsx
+++ b/lib/Die.tsx
@@ -40,7 +40,6 @@ const Die = forwardRef<DieRef, DieProps>(
     }: DieProps,
     ref
   ): JSX.Element => {
-    const dieRef = useRef<HTMLDivElement>(null)
     const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
     useEffect(() => {
@@ -60,6 +59,11 @@ const Die = forwardRef<DieRef, DieProps>(
     const clampedDefault = Math.min(Math.max(defaultRoll || 6, 1), 6)
     const [dieValue, setDieValue] = useState(clampedDefault)
     const [hasRolled, setHasRolled] = useState(false)
+    // Bumped on every roll so React remounts the animated element, which
+    // restarts the CSS keyframe animation reliably (replaces the old
+    // className-reset + forced-reflow hack that could fail to restart on
+    // rapid/overlapping rolls).
+    const [rollKey, setRollKey] = useState(0)
 
     // Only d6 faces are rendered; clamp to 1-6 regardless of sides prop
     const getRandomInt = () => {
@@ -68,15 +72,15 @@ const Die = forwardRef<DieRef, DieProps>(
     }
 
     const rollDie = (value?: number) => {
-      dieRef.current && (dieRef.current.className = `die`)
-      void dieRef.current?.offsetWidth
       const rawRoll = disableRandom ? dieValue : value || getRandomInt()
       const roll = Math.min(Math.max(rawRoll, 1), 6)
-      dieRef.current?.classList.add(`roll${roll}`)
+      // Drive the roll through state and remount the animated node (rollKey)
+      // so the CSS animation always restarts, even on rapid/overlapping rolls.
+      setDieValue(roll)
+      setHasRolled(true)
+      setRollKey((k) => k + 1)
       if (timeoutRef.current !== null) clearTimeout(timeoutRef.current)
       timeoutRef.current = setTimeout(() => {
-        setHasRolled(true)
-        setDieValue(roll)
         onRollDone(roll)
         timeoutRef.current = null
       }, rollTime * 1000)
@@ -172,8 +176,8 @@ const Die = forwardRef<DieRef, DieProps>(
         style={containerStyle}
       >
         <div
+          key={rollKey}
           className={`die ${hasRolled ? 'roll' : 'init-roll'}${dieValue}`}
-          ref={dieRef}
           style={rollStyle}
         >
           <div className='face six' style={Object.assign({}, faceStyle, f6Style)}>


### PR DESCRIPTION
## Summary

Fixes the bug where, on repeated/rapid **Roll All** presses, random dice would not animate (appear to "skip" the roll) even though the totals still completed.

## Root cause

I reproduced the demo's exact wiring in jsdom and traced every `class` mutation on a die. Findings:

- `rollDie` **is** called for all dice on every press (even overlapping clicks), and React **never** overwrites the animation class mid-roll. So the recent `rollCountRef`/`diceRefs` refactor is **not** dropping dice at the logic level.
- The weak point is the **CSS animation restart**: the roll was started imperatively with `el.className = 'die'` → `void el.offsetWidth` (force reflow) → `el.classList.add('roll' + n)`. That restart trick is unreliable, and the recent refactor removed a per-press `setState` (`setRollCount`) that previously forced a React commit each press — so rapid presses can now skip the style flush the restart depended on, intermittently failing to replay the animation.

## Fix

Drive the roll through React state and bump a `rollKey` so the animated element **remounts** on every roll. A freshly mounted node always plays its CSS keyframe animation, so the restart is now deterministic and independent of commit timing. The imperative `dieRef` + reflow hack is removed entirely.

## Verification

- `npm run build` — passes
- jsdom harness across full-wait, fast-overlapping (30ms), and near-completion press sequences: on **every** press all dice remount **and** carry a `roll[1-6]` class (the structural guarantee the animation restarts)
- ⚠️ **Not yet visually confirmed in a real browser** (no Chromium available in CI here). Kept as a **draft** — please deploy the demo and confirm the dice no longer skip on repeated Roll All presses.

https://claude.ai/code/session_01WZxB2pKeMMacz4juCo19DK

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZxB2pKeMMacz4juCo19DK)_